### PR TITLE
Implement IslandIs registration API and core services

### DIFF
--- a/Arshatid/Controllers/IslandIsController.cs
+++ b/Arshatid/Controllers/IslandIsController.cs
@@ -1,0 +1,129 @@
+using Arshatid.Databases;
+using Arshatid.Helpers;
+using Arshatid.Services;
+using ArshatidModels.Dtos;
+using ArshatidModels.Models.EF;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Arshatid.Controllers;
+
+[Route("islandapi")]
+[Authorize(AuthenticationSchemes = "IslandIs")]
+public class IslandIsController : Controller
+{
+    private readonly CurrentEventService _currentEventService;
+    private readonly ClaimsHelper _claimsHelper;
+    private readonly InviteeService _inviteeService;
+    private readonly RegistrationService _registrationService;
+    private readonly GeneralDbContext _generalDbContext;
+
+    public IslandIsController(CurrentEventService currentEventService,
+        ClaimsHelper claimsHelper,
+        InviteeService inviteeService,
+        RegistrationService registrationService,
+        GeneralDbContext generalDbContext)
+    {
+        _currentEventService = currentEventService;
+        _claimsHelper = claimsHelper;
+        _inviteeService = inviteeService;
+        _registrationService = registrationService;
+        _generalDbContext = generalDbContext;
+    }
+
+    private static DateTime GetNowLocal()
+    {
+        TimeZoneInfo tz = TimeZoneInfo.FindSystemTimeZoneById("Atlantic/Reykjavik");
+        return TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, tz);
+    }
+
+    [HttpGet("registration")]
+    public ActionResult<RegistrationDto?> GetRegistration()
+    {
+        DateTime nowLocal = GetNowLocal();
+        ArshatidEvent? currentEvent = _currentEventService.GetCurrentEvent(nowLocal);
+        if (currentEvent == null)
+        {
+            return Ok(null);
+        }
+
+        string ssn = _claimsHelper.GetSsn(User);
+        ArshatidInvitee? invitee = _inviteeService.GetInvitee(currentEvent.Pk, ssn);
+        if (invitee == null)
+        {
+            return BadRequest();
+        }
+
+        ArshatidRegistration? registration = _registrationService.GetByInvitee(currentEvent.Pk, invitee.Pk);
+        if (registration == null)
+        {
+            return Ok(null);
+        }
+
+        RegistrationDto dto = MapToDto(currentEvent, invitee, registration);
+        return Ok(dto);
+    }
+
+    [HttpPut("registration")]
+    public ActionResult<RegistrationDto> UpsertRegistration([FromBody] UpsertRegistrationRequest request)
+    {
+        DateTime nowLocal = GetNowLocal();
+        ArshatidEvent? currentEvent = _currentEventService.GetCurrentEvent(nowLocal);
+        if (currentEvent == null)
+        {
+            return BadRequest();
+        }
+
+        string ssn = _claimsHelper.GetSsn(User);
+        ArshatidInvitee? invitee = _inviteeService.GetInvitee(currentEvent.Pk, ssn);
+        if (invitee == null)
+        {
+            return BadRequest();
+        }
+
+        int plus = request.Plus ? 1 : 0;
+        ArshatidRegistration registration = _registrationService.Upsert(currentEvent.Pk, invitee.Pk, plus);
+        RegistrationDto dto = MapToDto(currentEvent, invitee, registration);
+        return Ok(dto);
+    }
+
+    [HttpDelete("registration")]
+    public IActionResult DeleteRegistration()
+    {
+        DateTime nowLocal = GetNowLocal();
+        ArshatidEvent? currentEvent = _currentEventService.GetCurrentEvent(nowLocal);
+        if (currentEvent == null)
+        {
+            return BadRequest();
+        }
+
+        string ssn = _claimsHelper.GetSsn(User);
+        ArshatidInvitee? invitee = _inviteeService.GetInvitee(currentEvent.Pk, ssn);
+        if (invitee == null)
+        {
+            return BadRequest();
+        }
+
+        _registrationService.Delete(currentEvent.Pk, invitee.Pk);
+        return NoContent();
+    }
+
+    private RegistrationDto MapToDto(ArshatidEvent currentEvent, ArshatidInvitee invitee, ArshatidRegistration registration)
+    {
+        string name = _generalDbContext.Person
+            .FirstOrDefault(p => p.Ssn == invitee.Ssn)?.Name ?? invitee.Ssn;
+
+        return new RegistrationDto
+        {
+            EventId = currentEvent.Pk,
+            RegistrationId = registration.Pk,
+            Plus = registration.Plus,
+            Invitee = new InviteeDto
+            {
+                InviteeId = invitee.Pk,
+                Ssn = invitee.Ssn,
+                Name = name
+            }
+        };
+    }
+}

--- a/Arshatid/Helpers/ClaimsHelper.cs
+++ b/Arshatid/Helpers/ClaimsHelper.cs
@@ -1,0 +1,11 @@
+using System.Security.Claims;
+
+namespace Arshatid.Helpers;
+
+public class ClaimsHelper
+{
+    public string GetSsn(ClaimsPrincipal user)
+    {
+        return user.FindFirst("nationalId")?.Value ?? string.Empty;
+    }
+}

--- a/Arshatid/Program.cs
+++ b/Arshatid/Program.cs
@@ -1,5 +1,7 @@
 using Arshatid.Authorization;
 using Arshatid.Databases;
+using Arshatid.Helpers;
+using Arshatid.Services;
 using GraphAuthentication.Authorization.AccessKey;
 using GraphAuthentication.Authorization.Entra;
 using GraphAuthentication.Authorization.Graph;
@@ -31,6 +33,10 @@ builder.Services.AddDbContext<ArshatidDbContext>(options =>
 
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddMemoryCache();
+builder.Services.AddScoped<CurrentEventService>();
+builder.Services.AddScoped<ClaimsHelper>();
+builder.Services.AddScoped<InviteeService>();
+builder.Services.AddScoped<RegistrationService>();
 
 
 // Add services to the container.

--- a/Arshatid/Services/CurrentEventService.cs
+++ b/Arshatid/Services/CurrentEventService.cs
@@ -1,0 +1,23 @@
+using Arshatid.Databases;
+using ArshatidModels.Models.EF;
+using Microsoft.EntityFrameworkCore;
+
+namespace Arshatid.Services;
+
+public class CurrentEventService
+{
+    private readonly ArshatidDbContext _dbContext;
+
+    public CurrentEventService(ArshatidDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public ArshatidEvent? GetCurrentEvent(DateTime nowLocal)
+    {
+        return _dbContext.ArshatidEvents
+            .Where(e => e.RegistrationStartTime <= nowLocal && nowLocal <= e.RegistrationEndTime)
+            .OrderByDescending(e => e.RegistrationStartTime)
+            .FirstOrDefault();
+    }
+}

--- a/Arshatid/Services/InviteeService.cs
+++ b/Arshatid/Services/InviteeService.cs
@@ -1,0 +1,20 @@
+using Arshatid.Databases;
+using ArshatidModels.Models.EF;
+
+namespace Arshatid.Services;
+
+public class InviteeService
+{
+    private readonly ArshatidDbContext _dbContext;
+
+    public InviteeService(ArshatidDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public ArshatidInvitee? GetInvitee(int eventId, string ssn)
+    {
+        return _dbContext.ArshatidInvitees
+            .FirstOrDefault(i => i.ArshatidFk == eventId && i.Ssn == ssn);
+    }
+}

--- a/Arshatid/Services/RegistrationService.cs
+++ b/Arshatid/Services/RegistrationService.cs
@@ -1,0 +1,61 @@
+using Arshatid.Databases;
+using ArshatidModels.Models.EF;
+
+namespace Arshatid.Services;
+
+public class RegistrationService
+{
+    private readonly ArshatidDbContext _dbContext;
+
+    public RegistrationService(ArshatidDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public ArshatidRegistration? GetByInvitee(int eventId, int inviteeId)
+    {
+        return _dbContext.ArshatidRegistrations
+            .FirstOrDefault(r => r.ArshatidFk == eventId && r.ArshatidInviteeFk == inviteeId);
+    }
+
+    public ArshatidRegistration Upsert(int eventId, int inviteeId, int plus)
+    {
+        ArshatidRegistration? registration = GetByInvitee(eventId, inviteeId);
+        if (registration == null)
+        {
+            ArshatidInvitee? invitee = _dbContext.ArshatidInvitees
+                .FirstOrDefault(i => i.Pk == inviteeId);
+            if (invitee == null)
+            {
+                throw new InvalidOperationException("Invitee not found");
+            }
+
+            registration = new ArshatidRegistration
+            {
+                ArshatidFk = eventId,
+                ArshatidInviteeFk = inviteeId,
+                Ssn = invitee.Ssn,
+                Plus = plus
+            };
+            _dbContext.ArshatidRegistrations.Add(registration);
+        }
+        else
+        {
+            registration.Plus = plus;
+            _dbContext.ArshatidRegistrations.Update(registration);
+        }
+
+        _dbContext.SaveChanges();
+        return registration;
+    }
+
+    public void Delete(int eventId, int inviteeId)
+    {
+        ArshatidRegistration? registration = GetByInvitee(eventId, inviteeId);
+        if (registration != null)
+        {
+            _dbContext.ArshatidRegistrations.Remove(registration);
+            _dbContext.SaveChanges();
+        }
+    }
+}

--- a/ArshatidModels/Dtos/InviteeDto.cs
+++ b/ArshatidModels/Dtos/InviteeDto.cs
@@ -1,0 +1,8 @@
+namespace ArshatidModels.Dtos;
+
+public sealed class InviteeDto
+{
+    public int InviteeId { get; set; }
+    public string Ssn { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+}

--- a/ArshatidModels/Dtos/RegistrationDto.cs
+++ b/ArshatidModels/Dtos/RegistrationDto.cs
@@ -1,0 +1,9 @@
+namespace ArshatidModels.Dtos;
+
+public sealed class RegistrationDto
+{
+    public int EventId { get; set; }
+    public int RegistrationId { get; set; }
+    public int Plus { get; set; }
+    public InviteeDto Invitee { get; set; } = new InviteeDto();
+}

--- a/ArshatidModels/Dtos/UpsertRegistrationRequest.cs
+++ b/ArshatidModels/Dtos/UpsertRegistrationRequest.cs
@@ -1,0 +1,6 @@
+namespace ArshatidModels.Dtos;
+
+public sealed class UpsertRegistrationRequest
+{
+    public bool Plus { get; set; }
+}


### PR DESCRIPTION
## Summary
- add registration DTOs
- introduce helper and services for current events, invitees, and registrations
- create IslandIsController for registration management and register services

## Testing
- ⚠️ `dotnet build` (command not found; attempted installation but apt repositories returned 403 errors)


------
https://chatgpt.com/codex/tasks/task_b_68b1eb49bc088333b4c94c202c8e2c76