### PR TITLE
Add registration link and plus-one option

### DIFF
--- a/ArshatidPublic/Controllers/HomeController.cs
+++ b/ArshatidPublic/Controllers/HomeController.cs
@@ -51,6 +51,7 @@ namespace ArshatidPublic.Controllers
 
             var registration = await response.Content.ReadFromJsonAsync<RegistrationDto>();
             var model = new RegistrationViewModel();
+            ViewBag.HasRegistration = registration != null;
             if (registration != null)
             {
                 model.Plus = registration.Plus == 1;

--- a/ArshatidPublic/Models/RegistrationViewModel.cs
+++ b/ArshatidPublic/Models/RegistrationViewModel.cs
@@ -1,7 +1,10 @@
 namespace ArshatidPublic.Models;
 
+using System.ComponentModel.DataAnnotations;
+
 public class RegistrationViewModel
 {
+    [Display(Name = "Plús einn")]
     public bool Plus { get; set; }
     public string? Alergies { get; set; }
 }

--- a/ArshatidPublic/Views/Home/Index.cshtml
+++ b/ArshatidPublic/Views/Home/Index.cshtml
@@ -6,5 +6,21 @@
 <div class="text-center">
     <p><img width="700px" src="img/CoverPhoto.jpg"></img></p>
     <h1 class="display-4">Árshátíð Kópavogsbæjar 2025</h1>
-    <p>Skráninig opnar eftir hádegi.</p>
+    <p>
+        <button id="goToRegistration" class="btn btn-success mb-2">Taka þátt í gleðinni</button>
+    </p>
+    <div class="d-flex justify-content-center">
+        <input id="jwtInput" class="form-control w-auto" placeholder="JWT" />
+    </div>
 </div>
+
+<script>
+    document.getElementById('goToRegistration').addEventListener('click', function () {
+        const jwt = (document.getElementById('jwtInput').value || '').trim();
+        let url = '@Url.Action("Skraning", "Home")';
+        if (jwt) {
+            url += '?jwt=' + encodeURIComponent(jwt);
+        }
+        window.location.href = url;
+    });
+</script>

--- a/ArshatidPublic/Views/Home/Skraning.cshtml
+++ b/ArshatidPublic/Views/Home/Skraning.cshtml
@@ -21,22 +21,32 @@
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
 
             <div class="col-12">
+                <div class="form-check">
+                    <input class="form-check-input" asp-for="Plus" />
+                    <label class="form-check-label" asp-for="Plus">Plús einn</label>
+                </div>
+            </div>
+
+            <div class="col-12">
                 <label class="form-label" asp-for="Alergies"></label>
                 <input class="form-control" asp-for="Alergies" />
                 <span class="text-danger" asp-validation-for="Alergies"></span>
             </div>
 
             <div class="col-12">
-                <button type="submit" class="btn btn-success me-2">Breyta</button>
+                <button type="submit" class="btn btn-success me-2">@((ViewBag.HasRegistration ?? false) ? "Breyta" : "Skrá")</button>
 
                 @* Separate post to Home/KemstEkki, keeping it inline *@
-                <button type="submit"
-                        class="btn btn-danger"
-                        formaction='@Url.Action("KemstEkki", "Home")'
-                        formmethod="post"
-                        onclick="return confirm('Ertu alveg viss um að þú getir ekki verið með? Við höfum svo gaman af félagsskap þínum.');">
-                    Kemst ekki
-                </button>
+                @if (ViewBag.HasRegistration ?? false)
+                {
+                    <button type="submit"
+                            class="btn btn-danger"
+                            formaction='@Url.Action("KemstEkki", "Home")'
+                            formmethod="post"
+                            onclick="return confirm('Ertu alveg viss um að þú getir ekki verið með? Við höfum svo gaman af félagsskap þínum.');">
+                        Kemst ekki
+                    </button>
+                }
             </div>
         </form>
     </div>


### PR DESCRIPTION
## Summary
- Replace informational text on home page with green "Taka þátt í gleðinni" button and JWT input to open registration
- Allow invitees to add a plus one and dynamically label actions based on existing registration
- Track existing registrations in controller to show/hide buttons accordingly

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b5952c76288333863d22322612e9fd