### PR TITLE
Add cost center selection and vegan option

### DIFF
--- a/Arshatid/Databases/ArshatidDbContext.cs
+++ b/Arshatid/Databases/ArshatidDbContext.cs
@@ -15,6 +15,7 @@ namespace Arshatid.Databases
         public DbSet<ArshatidImageType> ArshatidImageTypes { get; set; }
         public DbSet<ArshatidInvitee> ArshatidInvitees { get; set; }
         public DbSet<ArshatidRegistration> ArshatidRegistrations { get; set; }
+        public DbSet<ArshatidCostCenter> ArshatidCostCenters { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -26,15 +27,21 @@ namespace Arshatid.Databases
             modelBuilder.Entity<ArshatidRegistration>().ToTable("ArshatidRegistration", "dbo");
             modelBuilder.Entity<ArshatidImage>().ToTable("ArshatidImage", "dbo");
             modelBuilder.Entity<ArshatidImageType>().ToTable("ArshatidImageType", "dbo");
+            modelBuilder.Entity<ArshatidCostCenter>().ToTable("ArshatidCostCenter", "dbo");
 
-            // ArshatidEvent (principal) 1—* ArshatidInvitee (dependent)
+            // ArshatidEvent (principal) 1* ArshatidInvitee (dependent)
             modelBuilder.Entity<ArshatidInvitee>()
                 .HasOne(i => i.Event)
                 .WithMany(e => e.Invitees)
                 .HasForeignKey(i => i.ArshatidFk)
                 .OnDelete(DeleteBehavior.Cascade);
 
-            // ArshatidInvitee (principal) 1—* ArshatidRegistration (dependent)
+            modelBuilder.Entity<ArshatidInvitee>()
+                .HasOne(i => i.CostCenter)
+                .WithMany(c => c.Invitees)
+                .HasForeignKey(i => i.ArshatidCostCenterFk);
+
+            // ArshatidInvitee (principal) 1* ArshatidRegistration (dependent)
             modelBuilder.Entity<ArshatidRegistration>()
                 .HasOne(r => r.Invitee)
                 .WithMany(i => i.Registrations)

--- a/Arshatid/Services/RegistrationService.cs
+++ b/Arshatid/Services/RegistrationService.cs
@@ -19,9 +19,10 @@ public class RegistrationService
     }
 
     public ArshatidRegistration Upsert(
-        ArshatidInvitee invitee, 
-        int plus, 
-        string alergies
+        ArshatidInvitee invitee,
+        int plus,
+        string alergies,
+        bool vegan
     )
     {
         ArshatidRegistration? registration = GetByInvitee(invitee);
@@ -36,7 +37,8 @@ public class RegistrationService
             {
                 ArshatidInviteeFk = invitee.Pk,
                 Plus = plus,
-                Alergies = alergies
+                Alergies = alergies,
+                Vegan = vegan
             };
             _dbContext.ArshatidRegistrations.Add(registration);
         }
@@ -44,6 +46,7 @@ public class RegistrationService
         {
             registration.Plus = plus;
             registration.Alergies = alergies;
+            registration.Vegan = vegan;
             _dbContext.ArshatidRegistrations.Update(registration);
         }
 

--- a/ArshatidModels/Dtos/RegistrationDto.cs
+++ b/ArshatidModels/Dtos/RegistrationDto.cs
@@ -4,5 +4,7 @@ public sealed class RegistrationDto
 {
     public int RegistrationId { get; set; }
     public int Plus { get; set; }
+    public bool Vegan { get; set; }
+    public int? ArshatidCostCenterFk { get; set; }
     public InviteeDto Invitee { get; set; } = new InviteeDto();
 }

--- a/ArshatidModels/Dtos/UpsertRegistrationRequest.cs
+++ b/ArshatidModels/Dtos/UpsertRegistrationRequest.cs
@@ -4,4 +4,6 @@ public sealed class UpsertRegistrationRequest
 {
     public bool Plus { get; set; } = false;
     public string? Alergies { get; set; } = null!;
+    public bool Vegan { get; set; } = false;
+    public int? ArshatidCostCenterFk { get; set; }
 }

--- a/ArshatidModels/Models/EF/ArshatidCostCenter.cs
+++ b/ArshatidModels/Models/EF/ArshatidCostCenter.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ArshatidModels.Models.EF;
+
+[Table("ArshatidCostCenter", Schema = "dbo")]
+public class ArshatidCostCenter
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Pk { get; set; }
+
+    [Required]
+    [StringLength(255)]
+    public string Corporation { get; set; } = string.Empty;
+
+    [Required]
+    public int OrgUnitId { get; set; }
+
+    [Required]
+    [StringLength(255)]
+    public string OrgUnitName { get; set; } = string.Empty;
+
+    [Required]
+    public bool IsDivision { get; set; } = false;
+
+    [Required]
+    [StringLength(255)]
+    public string CostCenterName { get; set; } = string.Empty;
+
+    [Required]
+    public int CostCenterCode { get; set; }
+
+    public virtual ICollection<ArshatidInvitee> Invitees { get; set; } = new List<ArshatidInvitee>();
+}
+

--- a/ArshatidModels/Models/EF/ArshatidInvitee.cs
+++ b/ArshatidModels/Models/EF/ArshatidInvitee.cs
@@ -21,8 +21,13 @@ public class ArshatidInvitee
 
     public int ArshatidFk { get; set; }
 
+    public int? ArshatidCostCenterFk { get; set; }
+
     [ForeignKey(nameof(ArshatidFk))]
     public virtual Arshatid Event { get; set; } = null!;
+
+    [ForeignKey(nameof(ArshatidCostCenterFk))]
+    public virtual ArshatidCostCenter? CostCenter { get; set; }
 
     public virtual ICollection<ArshatidRegistration> Registrations { get; set; } = new List<ArshatidRegistration>();
 }

--- a/ArshatidModels/Models/EF/ArshatidRegistration.cs
+++ b/ArshatidModels/Models/EF/ArshatidRegistration.cs
@@ -17,6 +17,8 @@ public class ArshatidRegistration
     [StringLength(255)]
     public string? Alergies { get; set; }
 
+    public bool Vegan { get; set; } = false;
+
     [Required]
     public int ArshatidInviteeFk { get; set; }
 

--- a/ArshatidPublic/Models/RegistrationViewModel.cs
+++ b/ArshatidPublic/Models/RegistrationViewModel.cs
@@ -8,4 +8,10 @@ public class RegistrationViewModel
     public bool Plus { get; set; }
     [Display(Name = "Fæðuóþol")]
     public string? Alergies { get; set; }
+    [Display(Name = "Svið")]
+    public string? OrgUnitName { get; set; }
+    [Display(Name = "Kostnaðarstaður")]
+    public int? ArshatidCostCenterFk { get; set; }
+    [Display(Name = "Vegan")]
+    public bool Vegan { get; set; }
 }

--- a/ArshatidPublic/Views/Home/Skraning.cshtml
+++ b/ArshatidPublic/Views/Home/Skraning.cshtml
@@ -28,15 +28,38 @@
 
                 <div class="col-12">
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" data-val="true" data-val-required="The Plús einn field is required." id="Plus" name="Plus" value="true">
+                        <input class="form-check-input" asp-for="Plus" />
                         <label class="form-check-label" asp-for="Plus"></label>
                     </div>
                 </div>
 
                 <div class="col-12">
+                    <label class="form-label" for="OrgUnitName">Svið</label>
+                    <select class="form-select" id="OrgUnitName" name="OrgUnitName">
+                        <option value="">- Veldu Svið -</option>
+                        @foreach (var ou in (IEnumerable<string>)ViewBag.OrgUnits)
+                        {
+                            <option value="@ou" @(Model.OrgUnitName == ou ? "selected" : "")>@ou</option>
+                        }
+                    </select>
+                </div>
+
+                <div class="col-12">
+                    <label class="form-label" for="ArshatidCostCenterFk">Kostnaðarstaður</label>
+                    <select class="form-select" id="ArshatidCostCenterFk" name="ArshatidCostCenterFk"></select>
+                </div>
+
+                <div class="col-12">
                     <label class="form-label" for="Alergies">Fæðuóþol</label>
-                    <textarea class="form-control" id="Alergies" name="Alergies" rows="3"></textarea>
+                    <textarea class="form-control" id="Alergies" name="Alergies" rows="3">@Model.Alergies</textarea>
                     <span class="text-danger field-validation-valid" data-valmsg-for="Alergies" data-valmsg-replace="true"></span>
+                </div>
+
+                <div class="col-12">
+                    <div class="form-check">
+                        <input class="form-check-input" asp-for="Vegan" />
+                        <label class="form-check-label" asp-for="Vegan"></label>
+                    </div>
                 </div>
 
                 <div class="col-12">
@@ -55,6 +78,28 @@
                     }
                 </div>
             </form>
+            <script>
+                const costCenters = @Html.Raw(ViewBag.CostCentersJson ?? "[]");
+                const orgSelect = document.getElementById('OrgUnitName');
+                const ccSelect = document.getElementById('ArshatidCostCenterFk');
+                function populateCostCenters() {
+                    ccSelect.innerHTML = '';
+                    const selectedOrg = orgSelect.value;
+                    if (!selectedOrg) return;
+                    const filtered = costCenters.filter(c => c.OrgUnitName === selectedOrg);
+                    filtered.forEach(c => {
+                        const opt = document.createElement('option');
+                        opt.value = c.Pk;
+                        opt.text = c.CostCenterName;
+                        if (@(Model.ArshatidCostCenterFk ?? 0) === c.Pk) {
+                            opt.selected = true;
+                        }
+                        ccSelect.appendChild(opt);
+                    });
+                }
+                orgSelect.addEventListener('change', populateCostCenters);
+                document.addEventListener('DOMContentLoaded', function () { populateCostCenters(); });
+            </script>
         </main>
     </div>
 }


### PR DESCRIPTION
## Summary
- add `ArshatidCostCenter` entity with relations and vegan flag for registrations
- expose cost center list and support vegan/cost center on IslandIs API
- extend public registration page with org unit and cost center selectors plus vegan checkbox

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_b_68b5b3d9a710833389d5bd2ca5c3d40a