### PR TITLE
Persist cost center for invitee during registration

### DIFF
--- a/Arshatid/Controllers/IslandIsController.cs
+++ b/Arshatid/Controllers/IslandIsController.cs
@@ -86,6 +86,8 @@ public class IslandIsController : Controller
 
         int plus = request.Plus ? 1 : 0;
         invitee.ArshatidCostCenterFk = request.ArshatidCostCenterFk;
+        _dbContext.ArshatidInvitees.Update(invitee);
+        _dbContext.SaveChanges();
         ArshatidRegistration registration = _registrationService.Upsert(invitee, plus, request.Alergies ?? string.Empty, request.Vegan);
         RegistrationDto dto = MapToDto(currentEvent, invitee, registration);
         return Ok(dto);


### PR DESCRIPTION
## Summary
- ensure UpsertRegistration stores incoming `ArshatidCostCenterFk` on `ArshatidInvitee`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b5bcbf5dbc83338a70f542fed1aedb