### PR TITLE
Add Swagger configuration for IslandIs API

### DIFF
--- a/Arshatid/Controllers/IslandIsController.cs
+++ b/Arshatid/Controllers/IslandIsController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Arshatid.Controllers;
 
+[ApiController]
 [Route("islandapi")]
 [Authorize(AuthenticationSchemes = "IslandIs")]
 public class IslandIsController : Controller

--- a/Arshatid/Program.cs
+++ b/Arshatid/Program.cs
@@ -12,6 +12,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using QuestPDF.Infrastructure;
 using System.Diagnostics;
 using System.Globalization;
+using Microsoft.OpenApi.Models;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -64,6 +65,15 @@ builder.Services.AddScoped<CurrentEventService>();
 builder.Services.AddScoped<ClaimsHelper>();
 builder.Services.AddScoped<InviteeService>();
 builder.Services.AddScoped<RegistrationService>();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new OpenApiInfo { Title = "Arshatid API", Version = "v1" });
+    options.DocInclusionPredicate((_, api) =>
+        api.RelativePath != null &&
+        api.RelativePath.StartsWith("islandapi", StringComparison.OrdinalIgnoreCase));
+});
+
 
 
 // Add services to the container.
@@ -114,6 +124,12 @@ app.UseStaticFiles();
 app.UseRouting();
 
 app.UseAuthorization();
+
+app.UseSwagger();
+app.UseSwaggerUI(c =>
+{
+    c.SwaggerEndpoint("/swagger/v1/swagger.json", "Arshatid API V1");
+});
 
 app.MapControllerRoute(
     name: "default",


### PR DESCRIPTION
## Summary
- enable Swagger for the project and restrict docs to IslandIs endpoints
- mark IslandIsController as an API controller

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b5cd2afd60833396505b6abf2d6b66