### PR TITLE
Enable Swagger bearer token input

### DIFF
--- a/Arshatid/Program.cs
+++ b/Arshatid/Program.cs
@@ -72,6 +72,29 @@ builder.Services.AddSwaggerGen(options =>
     options.DocInclusionPredicate((_, api) =>
         api.RelativePath != null &&
         api.RelativePath.StartsWith("islandapi", StringComparison.OrdinalIgnoreCase));
+    options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        In = ParameterLocation.Header,
+        Description = "Please enter a valid token",
+        Name = "Authorization",
+        Type = SecuritySchemeType.Http,
+        BearerFormat = "JWT",
+        Scheme = "Bearer"
+    });
+    options.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            new string[] {}
+        }
+    });
 });
 
 


### PR DESCRIPTION
## Summary
- enable Swagger Bearer authorization UI by defining security scheme and requirement

## Testing
- `dotnet build Arshatid.sln` *(fails: bash: command not found: dotnet)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68b5cfdef8c88333ba0ae1bf5c3178b3