### PR TITLE
Handle 204 responses for missing registration

### DIFF
--- a/ArshatidPublic/Controllers/HomeController.cs
+++ b/ArshatidPublic/Controllers/HomeController.cs
@@ -63,7 +63,12 @@ namespace ArshatidPublic.Controllers
                 return View(new RegistrationViewModel());
             }
 
-            var registration = await response.Content.ReadFromJsonAsync<RegistrationDto>();
+            RegistrationDto? registration = null;
+            if (response.StatusCode != HttpStatusCode.NoContent)
+            {
+                registration = await response.Content.ReadFromJsonAsync<RegistrationDto>();
+            }
+
             var model = new RegistrationViewModel();
             ViewBag.HasRegistration = registration != null;
             if (registration != null)


### PR DESCRIPTION
## Summary
- Skip deserializing registration when API returns `204 No Content` and set `HasRegistration` accordingly

## Testing
- `dotnet test` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b5d3eaeb248333b7fa7f2cd59adc3a