### PR TITLE
Replace Svið dropdown with searchable cost center list

### DIFF
--- a/ArshatidPublic/Controllers/HomeController.cs
+++ b/ArshatidPublic/Controllers/HomeController.cs
@@ -3,10 +3,10 @@ using ArshatidModels.Models.EF;
 using ArshatidPublic.Classes;
 using ArshatidPublic.Models;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Json;
-using System.Text.Json;
 
 namespace ArshatidPublic.Controllers
 {
@@ -44,12 +44,9 @@ namespace ArshatidPublic.Controllers
             List<ArshatidCostCenter> costCenters = centersResponse.IsSuccessStatusCode
                 ? await centersResponse.Content.ReadFromJsonAsync<List<ArshatidCostCenter>>()
                 : new List<ArshatidCostCenter>();
-            ViewBag.CostCentersJson = JsonSerializer.Serialize(costCenters);
-            ViewBag.OrgUnits = costCenters
-                .Where(c => c.IsDivision)
-                .Select(c => c.OrgUnitName)
-                .Distinct()
-                .OrderBy(n => n)
+            ViewBag.CostCenters = costCenters
+                .OrderBy(c => c.CostCenterName)
+                .Select(c => new SelectListItem(c.CostCenterName, c.Pk.ToString()))
                 .ToList();
 
             if (response.StatusCode == HttpStatusCode.BadRequest)
@@ -76,11 +73,6 @@ namespace ArshatidPublic.Controllers
                 model.Plus = registration.Plus == 1;
                 model.Vegan = registration.Vegan;
                 model.ArshatidCostCenterFk = registration.ArshatidCostCenterFk;
-                if (model.ArshatidCostCenterFk != null)
-                {
-                    var selected = costCenters.FirstOrDefault(c => c.Pk == model.ArshatidCostCenterFk);
-                    model.OrgUnitName = selected?.OrgUnitName;
-                }
             }
             return View(model);
         }

--- a/ArshatidPublic/Models/RegistrationViewModel.cs
+++ b/ArshatidPublic/Models/RegistrationViewModel.cs
@@ -8,8 +8,6 @@ public class RegistrationViewModel
     public bool Plus { get; set; }
     [Display(Name = "Fæðuóþol")]
     public string? Alergies { get; set; }
-    [Display(Name = "Svið")]
-    public string? OrgUnitName { get; set; }
     [Display(Name = "Kostnaðarstaður")]
     public int? ArshatidCostCenterFk { get; set; }
     [Display(Name = "Vegan")]

--- a/ArshatidPublic/Views/Home/Skraning.cshtml
+++ b/ArshatidPublic/Views/Home/Skraning.cshtml
@@ -34,26 +34,14 @@
                 </div>
 
                 <div class="col-12">
-                    <label class="form-label" for="OrgUnitName">Svið</label>
-                    <select class="form-select" id="OrgUnitName" name="OrgUnitName">
-                        <option value="">Veldu svið</option>
-                        @foreach (string ou in (IEnumerable<string>)ViewBag.OrgUnits)
-                        {
-                            if (string.Equals(Model.OrgUnitName, ou, StringComparison.Ordinal))
-                            {
-                                <option value="@ou" selected>@ou</option>
-                            }
-                            else
-                            {
-                                <option value="@ou">@ou</option>
-                            }
-                        }
+                    <label class="form-label" asp-for="ArshatidCostCenterFk"></label>
+                    <select class="form-select js-choices"
+                            asp-for="ArshatidCostCenterFk"
+                            asp-items="@(ViewBag.CostCenters as IEnumerable<SelectListItem>)"
+                            data-placeholder="Veldu kostnaðarstað">
+                        <option value="">Veldu kostnaðarstað</option>
                     </select>
-                </div>
-
-                <div class="col-12">
-                    <label class="form-label" for="ArshatidCostCenterFk">Kostnaðarstaður</label>
-                    <select class="form-select" id="ArshatidCostCenterFk" name="ArshatidCostCenterFk"></select>
+                    <span class="text-danger" asp-validation-for="ArshatidCostCenterFk"></span>
                 </div>
 
                 <div class="col-12">
@@ -85,28 +73,29 @@
                     }
                 </div>
             </form>
-            <script>
-                const costCenters = @Html.Raw(ViewBag.CostCentersJson ?? "[]");
-                const orgSelect = document.getElementById('OrgUnitName');
-                const ccSelect = document.getElementById('ArshatidCostCenterFk');
-                function populateCostCenters() {
-                    ccSelect.innerHTML = '';
-                    const selectedOrg = orgSelect.value;
-                    if (!selectedOrg) return;
-                    const filtered = costCenters.filter(c => c.OrgUnitName === selectedOrg);
-                    filtered.forEach(c => {
-                        const opt = document.createElement('option');
-                        opt.value = c.Pk;
-                        opt.text = c.CostCenterName;
-                        if (@(Model.ArshatidCostCenterFk ?? 0) === c.Pk) {
-                            opt.selected = true;
-                        }
-                        ccSelect.appendChild(opt);
-                    });
-                }
-                orgSelect.addEventListener('change', populateCostCenters);
-                document.addEventListener('DOMContentLoaded', function () { populateCostCenters(); });
-            </script>
         </main>
     </div>
+}
+
+@section Styles {
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/choices.js@10.2.0/public/assets/styles/choices.min.css" />
+}
+
+@section Scripts {
+    <script src="https://cdn.jsdelivr.net/npm/choices.js@10.2.0/public/assets/scripts/choices.min.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            document.querySelectorAll('.js-choices').forEach(function (el) {
+                new Choices(el, {
+                    searchEnabled: true,
+                    shouldSort: false,
+                    removeItemButton: false,
+                    allowHTML: false,
+                    placeholder: true,
+                    placeholderValue: el.dataset.placeholder || 'Veldu…'
+                });
+            });
+        });
+    </script>
 }

--- a/ArshatidPublic/Views/Shared/_Layout_plain.cshtml
+++ b/ArshatidPublic/Views/Shared/_Layout_plain.cshtml
@@ -14,6 +14,7 @@
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#008c44">
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="theme-color" content="#ffffff">
+    @await RenderSectionAsync("Styles", required: false)
 </head>
 <body>
     <div class="container">

--- a/ArshatidPublic/Views/_ViewImports.cshtml
+++ b/ArshatidPublic/Views/_ViewImports.cshtml
@@ -1,3 +1,4 @@
 ﻿@using ArshatidPublic
 @using ArshatidPublic.Models
+@using Microsoft.AspNetCore.Mvc.Rendering
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
## Summary
- show all cost centers in a single searchable combo box
- preload cost centers in controller and remove OrgUnitName
- add layout hook and scripts for Choices.js

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68b5f45e71d083339fed25b7985eda20