### PR TITLE
Fix registration action ambiguity

### DIFF
--- a/ArshatidPublic/Controllers/HomeController.cs
+++ b/ArshatidPublic/Controllers/HomeController.cs
@@ -80,7 +80,7 @@ namespace ArshatidPublic.Controllers
         [HttpPost]
         [ValidateAntiForgeryToken]
         [ManualJwtSignIn]
-        public async Task<IActionResult> Skraning(RegistrationViewModel model)
+        public async Task<IActionResult> SkraningUpsert(RegistrationViewModel model)
         {
             var client = _clientFactory.CreateClient("ArshatidApi");
             var request = new UpsertRegistrationRequest

--- a/ArshatidPublic/Views/Home/Skraning.cshtml
+++ b/ArshatidPublic/Views/Home/Skraning.cshtml
@@ -19,7 +19,7 @@
 {
     <div b-191jc0ugh8="" class="container" style="max-width: 1000px;">
         <main b-191jc0ugh8="" role="main" class="pb-3">
-            <form asp-controller="Home" asp-action="Skraning" method="post" class="row g-3">
+            <form asp-controller="Home" asp-action="SkraningUpsert" method="post" class="row g-3">
                 @Html.AntiForgeryToken()
 
                 <div asp-validation-summary="ModelOnly" class="text-danger"></div>


### PR DESCRIPTION
## Summary
- rename `Skraning` POST action to `SkraningUpsert` to avoid ambiguity
- update registration view to post to `SkraningUpsert`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68b5fe05f3b88333a18fb0a048f5f4bd