### PR TITLE
Handle missing eventId in registrations index

### DIFF
--- a/Arshatid/Views/Registrations/Index.cshtml
+++ b/Arshatid/Views/Registrations/Index.cshtml
@@ -1,6 +1,6 @@
 @{
     string eventIdQuery = Context.Request.Query["eventId"];
-    int eventId = int.Parse(eventIdQuery);
+    int eventId = int.TryParse(eventIdQuery, out var parsedEventId) ? parsedEventId : 0;
     ViewData["Title"] = "Skráningar";
     ArshatidModels.Models.EF.Arshatid evnt = (ArshatidModels.Models.EF.Arshatid)ViewBag.Event;
     Dictionary<DateTime, int> histogram = (Dictionary<DateTime, int>)ViewBag.Histogram;


### PR DESCRIPTION
## Summary
- avoid ArgumentNullException when `eventId` query parameter is missing on the registrations index view

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68b726845c4083338735d55214268b29