### PR TITLE
Expose image retrieval endpoint and use cached images in public site

### DIFF
--- a/Arshatid/Controllers/IslandIsController.cs
+++ b/Arshatid/Controllers/IslandIsController.cs
@@ -128,6 +128,27 @@ public class IslandIsController : Controller
         return Ok(centers);
     }
 
+    [AllowAnonymous]
+    [HttpGet("events/{eventId}/images/{imageName}")]
+    public IActionResult GetImage(int eventId, string imageName)
+    {
+        var type = _dbContext.ArshatidImageTypes
+            .FirstOrDefault(t => t.Name == imageName);
+        if (type == null)
+        {
+            return NotFound();
+        }
+
+        ArshatidImage? image = _dbContext.ArshatidImages
+            .FirstOrDefault(i => i.ArshatidFk == eventId && i.ImageTypeFk == type.Pk);
+        if (image == null)
+        {
+            return NotFound();
+        }
+
+        return File(image.ImageData, image.ContentType);
+    }
+
     private RegistrationDto MapToDto(ArshatidModels.Models.EF.Arshatid currentEvent, ArshatidInvitee invitee, ArshatidRegistration registration)
     {
         string name = _generalDbContext.Person

--- a/ArshatidPublic/Views/Home/Index.cshtml
+++ b/ArshatidPublic/Views/Home/Index.cshtml
@@ -4,7 +4,7 @@
 }
 
 <div class="text-center">
-    <p><img width="700px" src="~/img/CoverPhoto.jpg"></img></p>
+    <p><img width="700px" src="@Url.Action("Image", "Home", new { imageName = "Banner" })"></img></p>
     <h1 class="display-4">Árshátíð Kópavogsbæjar 2025</h1>
     <a href="https://innskra.kopavogur.is/aha" class="btn btn-success mb-2">Taka þátt í gleðinni</a>
     <p class="xd-none">

--- a/ArshatidPublic/Views/Home/Skraning.cshtml
+++ b/ArshatidPublic/Views/Home/Skraning.cshtml
@@ -5,7 +5,7 @@
 }
 
 <p>
-    <img src="~/img/CoverPhoto.jpg" class="img-fluid" alt="Event Cover Photo">
+    <img src="@Url.Action("Image", "Home", new { imageName = "Banner" })" class="img-fluid" alt="Event Cover Photo">
 </p>
 
 @* Show warning if user is not invited *@

--- a/ArshatidPublic/Views/Home/Sorry.cshtml
+++ b/ArshatidPublic/Views/Home/Sorry.cshtml
@@ -4,7 +4,7 @@
 }
 
 <div class="text-center">
-    <p><img width="500px" src="~/img/CoverPhoto.jpg"></img></p>
+    <p><img width="500px" src="@Url.Action("Image", "Home", new { imageName = "Banner" })"></img></p>
     <h1 class="display-4">En leiðinlegt</h1>
     <p>
         Það hefði verið svo gaman að hafa þig með okkur.<br/>

--- a/ArshatidPublic/Views/Home/Super.cshtml
+++ b/ArshatidPublic/Views/Home/Super.cshtml
@@ -4,7 +4,7 @@
 }
 
 <div class="text-center">
-    <p><img width="500px" src="~/img/CoverPhoto.jpg"></img></p>
+    <p><img width="500px" src="@Url.Action("Image", "Home", new { imageName = "Banner" })"></img></p>
     <h1 class="display-4">Jibbí!</h1>
     <h2>Sjáumst í partíinu</h2>
 </div>

--- a/ArshatidPublic/appsettings.Development.json
+++ b/ArshatidPublic/appsettings.Development.json
@@ -6,6 +6,8 @@
     }
   },
   "ArshatidApi": {
-    "BaseUrl": "https://kop-lindrest.kopavogur.is/Arshatid/islandapi/"
-  }
+    "BaseUrl": "https://kop-lindrest.kopavogur.is/Arshatid/islandapi/",
+    "EventId": 1
+  },
+  "ImageCacheMinutes": 60
 }

--- a/ArshatidPublic/appsettings.json
+++ b/ArshatidPublic/appsettings.json
@@ -4,8 +4,10 @@
     "Audience": "@kopavogur.is/thjonustugatt"
   },
   "ArshatidApi": {
-    "BaseUrl": "https://kop-lindrest.kopavogur.is/Arshatid/islandapi/"
+    "BaseUrl": "https://kop-lindrest.kopavogur.is/Arshatid/islandapi/",
+    "EventId": 1
   },
+  "ImageCacheMinutes": 60,
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## Summary
- Add anonymous image lookup by name to IslandIs API
- Serve images in public site via REST with in-memory caching and configurable retention
- Use dynamic banner image on Home pages instead of static CoverPhoto

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68b80c34a4148333bf1c3d15f5229756