### PR TITLE
Fix: Correct eventId in export URL and invitee count

### DIFF
--- a/Arshatid/Controllers/RegistrationsController.cs
+++ b/Arshatid/Controllers/RegistrationsController.cs
@@ -31,7 +31,9 @@ public class RegistrationsController : Controller
         List<ArshatidRegistration> registrations = _dbContext.ArshatidRegistrations
             .Where((ArshatidRegistration r) => r.Invitee.ArshatidFk == eventId)
             .ToList();
-        int inviteeCount = registrations.Count;
+        int inviteeCount = _dbContext.ArshatidInvitees
+            .Count((ArshatidInvitee i) => i.ArshatidFk == eventId);
+        int registeredCount = registrations.Count;
         int plusCount = registrations.Sum((ArshatidRegistration r) => r.Plus);
         Dictionary<DateTime, int> histogram = registrations
             .GroupBy((ArshatidRegistration r) => DateTime.Today)
@@ -39,8 +41,10 @@ public class RegistrationsController : Controller
                           (IGrouping<DateTime, ArshatidRegistration> g) => g.Count());
         ViewBag.Event = evnt;
         ViewBag.InviteeCount = inviteeCount;
+        ViewBag.RegisteredCount = registeredCount;
         ViewBag.PlusCount = plusCount;
         ViewBag.Histogram = histogram;
+        ViewBag.EventId = eventId;
         return View();
     }
 

--- a/Arshatid/Views/Registrations/Index.cshtml
+++ b/Arshatid/Views/Registrations/Index.cshtml
@@ -1,15 +1,15 @@
 @{
-    string eventIdQuery = Context.Request.Query["eventId"];
-    int eventId = int.TryParse(eventIdQuery, out var parsedEventId) ? parsedEventId : 0;
+    int eventId = (int)ViewBag.EventId;
     ViewData["Title"] = "Skráningar";
     ArshatidModels.Models.EF.Arshatid evnt = (ArshatidModels.Models.EF.Arshatid)ViewBag.Event;
     Dictionary<DateTime, int> histogram = (Dictionary<DateTime, int>)ViewBag.Histogram;
     int inviteeCount = (int)ViewBag.InviteeCount;
+    int registeredCount = (int)ViewBag.RegisteredCount;
     int plusCount = (int)ViewBag.PlusCount;
 }
 <h1>Skráningar</h1>
 <div class="d-flex justify-content-between">
-    <div>Boðsgestir: @inviteeCount | Plús: @plusCount | Samtals skráningar: @(inviteeCount + plusCount)</div>
+    <div>Boðsgestir: @inviteeCount | Plús: @plusCount | Samtals skráningar: @(registeredCount + plusCount)</div>
     <div>
         <a class="btn btn-primary me-2" href="/Registrations/export?eventId=@eventId&format=csv" title="Sækja skráningar CSV"><i class="bi bi-download"></i> CSV</a>
         <a class="btn btn-secondary" href="/Registrations/export?eventId=@eventId&format=xlsx" title="Sækja skráningar XLSX"><i class="bi bi-download"></i> XLSX</a>


### PR DESCRIPTION
This commit fixes two bugs on the event registrations page:

1. The export link was hardcoded with eventId=0. This has been fixed by passing the correct eventId from the controller to the view.

2. The number of invitees was incorrectly showing the number of registered users, which was 0 if no one had registered. This has been corrected to show the total number of invitees for the event. The 'total registrations' calculation has also been corrected to use the number of registered users.